### PR TITLE
fix: migrate prism to highlightjs

### DIFF
--- a/web/src/components/ChatLog/ChatMessage/TextMessage/index.jsx
+++ b/web/src/components/ChatLog/ChatMessage/TextMessage/index.jsx
@@ -1,7 +1,8 @@
 import Markdown from "react-markdown";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import remarkGfm from "remark-gfm";
-import { darcula } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { darcula } from "react-syntax-highlighter/dist/esm/styles/hljs";
+
 
 const TextMessage = ({ className, text }) => {
     return (


### PR DESCRIPTION
## Pull Request Checklist

- [ ] Test cases added for changed code.

## Describe what you have changed in this PR.

Prism seems to be broken after I upgraded the version of `react-syntax-highlighter` and `react-markdown`, switching to highlightjs seems to solve this problem.
