### PR TITLE
chore: Explicitly specify EG_AVAILABILITY_MODE

### DIFF
--- a/manifests/third-party/jupyter-enterprise-gateway/patches/patch-ha.yaml
+++ b/manifests/third-party/jupyter-enterprise-gateway/patches/patch-ha.yaml
@@ -40,6 +40,8 @@ spec:
             value: python_kubernetes
           - name: EG_INHERITED_ENVS
             value: PATH
+          - name: EG_AVAILABILITY_MODE
+            value: replication
           # 2 envs related to session persistence
           - name: EG_KERNEL_SESSION_PERSISTENCE
             value: "True"


### PR DESCRIPTION
This should be optional, however explicitly specifying it makes things clear.